### PR TITLE
Add field/OBB collision

### DIFF
--- a/inc/simulation/field.h
+++ b/inc/simulation/field.h
@@ -40,4 +40,6 @@
   static float r;
   static float R;
 
+  static int axis_box_collision(const wall& w, const vec3& diagonal, const vec3& center, ray& contact_point);
+
 };


### PR DESCRIPTION
obb is equivalent to aabb with arbitrary axis. So we reuse
the core of the field/aabb collision logic except that
we rotate the field before finding the normals.

Once we have a result, we rotate the results back.