### PR TITLE
Expose FollowPath::calculate_plan to python

### DIFF
--- a/python/src/follow_path_pybind11.cc
+++ b/python/src/follow_path_pybind11.cc
@@ -9,5 +9,6 @@ void init_followpath(pybind11::module & m) {
     .def_readwrite("path", &FollowPath::path)
     .def_readonly("finished", &FollowPath::finished)
     .def_readonly("controls", &FollowPath::controls)
-    .def("step", &FollowPath::step);
+    .def("step", &FollowPath::step)
+    .def("calculate_plan", &FollowPath::calculate_plan);
 }


### PR DESCRIPTION
`FollowPath` does not work if `calculate_plan` is not called.