### PR TITLE
Use initialize to set the asset directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ __pycache__/
 *.ipdb
 *.pyd
 *.pyi
+python/rlutilities/assets
 
 # Distribution / packaging
 .Python

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ if (TARGET_LANGUAGE STREQUAL "python" OR TARGET_LANGUAGE STREQUAL "both")
 
   set_target_properties(rlutilities PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/python/rlutilities)
 
+  file(COPY ${PROJECT_SOURCE_DIR}/assets DESTINATION ${PROJECT_SOURCE_DIR}/python/rlutilities)
+
 endif()
 
 set(ASSET_DIR ${PROJECT_SOURCE_DIR}/assets/)

--- a/inc/rlutilities.h
+++ b/inc/rlutilities.h
@@ -1,5 +1,5 @@
 #include "simulation/game.h"
 
 namespace rlu {
-  void initialize(std::string = std::string("soccar"));
+  void initialize(std::string);
 }

--- a/python/rlutilities/__init__.py
+++ b/python/rlutilities/__init__.py
@@ -1,6 +1,10 @@
 import sys
+from pathlib import Path
 from .rlutilities import mechanics, simulation, linear_algebra, initialize
 
 sys.modules["rlutilities.mechanics"] = mechanics
 sys.modules["rlutilities.simulation"] = simulation
 sys.modules["rlutilities.linear_algebra"] = linear_algebra
+
+asset_dir = Path(__file__).parent / "assets"
+initialize(asset_dir.as_posix() + "/")

--- a/src/rlutilities.cc
+++ b/src/rlutilities.cc
@@ -36,12 +36,12 @@ mesh throwback_corner_wall_2{};
 
 namespace rlu {
 
-  void initialize(std::string mode) {
+  void initialize(std::string asset_dir) {
 
-    auto read_mesh = [](std::string str) {
+    auto read_mesh = [asset_dir](std::string str) {
       return mesh(
-        read_binary<int>(ASSET_DIR + str + "_ids.bin"),
-        read_binary<float>(ASSET_DIR + str + "_vertices.bin")
+        read_binary<int>(asset_dir + str + "_ids.bin"),
+        read_binary<float>(asset_dir + str + "_vertices.bin")
       );
     };
 
@@ -66,13 +66,14 @@ namespace rlu {
     throwback_corner_wall_1 = read_mesh("throwback/throwback_corner_wall_1");
     throwback_corner_wall_2 = read_mesh("throwback/throwback_corner_wall_2");
 
-    auto prefix = ASSET_DIR + std::string("soccar/soccar_navigation_");
+    auto prefix = asset_dir + std::string("soccar/soccar_navigation_");
     Navigator::init_statics(
         read_binary<Graph::edge>(prefix + "graph.bin"),
         read_binary<vec3>(prefix + "nodes.bin"),
         read_binary<vec3>(prefix + "normals.bin"));
 
-    Game::set_mode(mode);
+    // User should call this instead.
+    // Game::set_mode(mode);
 
   }
 

--- a/src/rlutilities.cc
+++ b/src/rlutilities.cc
@@ -72,6 +72,8 @@ namespace rlu {
         read_binary<vec3>(prefix + "nodes.bin"),
         read_binary<vec3>(prefix + "normals.bin"));
 
+    ReorientML::set_model(Model(read_binary<float>(asset_dir + "ML/reorient_ML_model.bin")));
+    
     // User should call this instead.
     // Game::set_mode(mode);
 

--- a/src/rlutilities.cc
+++ b/src/rlutilities.cc
@@ -36,7 +36,7 @@ mesh throwback_corner_wall_2{};
 
 namespace rlu {
 
-  void initialize(std::string asset_dir) {
+  void initialize(std::string asset_dir = ASSET_DIR) {
 
     auto read_mesh = [asset_dir](std::string str) {
       return mesh(


### PR DESCRIPTION
This is needed to make rlutilities movable. If this is not done, it only works on the machine of who built it and only if they don't move the asset directory.