### PR TITLE
Fix ball simulation when ball is frozen

### DIFF
--- a/src/simulation/ball.cc
+++ b/src/simulation/ball.cc
@@ -68,10 +68,10 @@ void Ball::step(float dt) {
 
 	}
 	else {
-
-		v += (drag * v + gravity) * dt;
-		x += v * dt;
-
+    if (norm(v) > 0) { // If the ball has exactly 0 velocity, it will be frozen
+		  v += (drag * v + gravity) * dt;
+		  x += v * dt;
+    }
 	}
 
 	w *= fminf(1.0, w_max / norm(w));


### PR DESCRIPTION
Should probably use squared length instead of length because sqrts are expensive but